### PR TITLE
Add class to write Avro files and add PoC update_table api call

### DIFF
--- a/python/pyiceberg/avro/file.py
+++ b/python/pyiceberg/avro/file.py
@@ -20,13 +20,14 @@ Avro reader for reading Avro files
 """
 from __future__ import annotations
 
-import json
+import json, os, io
 from dataclasses import dataclass
 from types import TracebackType
 from typing import (
     Callable,
     Dict,
     Generic,
+    List,
     Optional,
     Type,
     TypeVar,
@@ -34,9 +35,11 @@ from typing import (
 
 from pyiceberg.avro.codecs import KNOWN_CODECS, Codec
 from pyiceberg.avro.decoder import BinaryDecoder
+from pyiceberg.avro.encoder import BinaryEncoder
 from pyiceberg.avro.reader import Reader
-from pyiceberg.avro.resolver import construct_reader, resolve
-from pyiceberg.io import InputFile, InputStream
+from pyiceberg.avro.writer import Writer
+from pyiceberg.avro.resolver import construct_reader, resolve, construct_writer
+from pyiceberg.io import InputFile, InputStream, OutputStream, OutputFile
 from pyiceberg.io.memory import MemoryInputStream
 from pyiceberg.schema import Schema
 from pyiceberg.typedef import EMPTY_DICT, Record, StructProtocol
@@ -199,3 +202,76 @@ class AvroFile(Generic[D]):
 
     def _read_header(self) -> AvroFileHeader:
         return construct_reader(META_SCHEMA, {-1: AvroFileHeader}).read(self.decoder)
+
+
+class AvroOutputFile(Generic[D]):
+    output_file: OutputFile
+    output_stream: OutputStream
+    schema: Schema
+    schema_name: str
+    encoder: BinaryEncoder
+    sync_bytes: bytes
+    writer: Writer
+
+    def __init__(
+        self,
+        output_file: OutputFile,
+        schema: Schema,
+        schema_name: str
+    ) -> None:
+        self.output_file = output_file
+        self.schema      = schema
+        self.schema_name = schema_name
+        self.sync_bytes  = os.urandom(SYNC_SIZE)
+        self.writer      = construct_writer(self.schema)
+
+    def __enter__(self) -> AvroFile[D]:
+        """
+        Opens the file and writes the header
+
+        Returns:
+            The file object to write records to
+        """
+        self.output_stream = self.output_file.create(overwrite = True)
+        self.encoder = BinaryEncoder(self.output_stream)
+
+        self._write_header()
+        self.writer = construct_writer(self.schema)
+
+        return self
+
+    def __exit__(
+        self, exctype: Optional[Type[BaseException]], excinst: Optional[BaseException], exctb: Optional[TracebackType]
+    ) -> None:
+        self.output_stream.close()
+
+    def _write_header(self):
+        json_schema = json.dumps(AvroSchemaConversion().iceberg_to_avro(
+            self.schema,
+            schema_name=self.schema_name
+        ))
+        header = AvroFileHeader(
+            magic = MAGIC,
+            meta = {
+                _SCHEMA_KEY: json_schema,
+                _CODEC_KEY: "null"
+            },
+            sync = self.sync_bytes
+        )
+        construct_writer(META_SCHEMA).write(self.encoder, header)
+
+    def write_block(self, objects: List[D]) -> None:
+
+        in_memory = io.BytesIO()
+        block_content_encoder = BinaryEncoder(output_stream = in_memory)
+        for obj in objects:
+            self.writer.write(block_content_encoder, obj)
+        block_content = in_memory.getvalue()
+
+        self.encoder.write_int(len(objects))
+        self.encoder.write_int(len(block_content))
+        self.encoder.write(block_content)
+        self.encoder.write_bytes_fixed(self.sync_bytes)
+
+
+

--- a/python/pyiceberg/avro/resolver.py
+++ b/python/pyiceberg/avro/resolver.py
@@ -56,6 +56,7 @@ from pyiceberg.avro.writer import (
     IntegerWriter,
     ListWriter,
     MapWriter,
+    OptionWriter,
     StringWriter,
     StructWriter,
     TimestamptzWriter,
@@ -135,7 +136,10 @@ class ConstructWriter(SchemaVisitorPerPrimitiveType[Writer]):
         return StructWriter(tuple(field_results))
 
     def field(self, field: NestedField, field_result: Writer) -> Writer:
-        return field_result
+        if field.required:
+            return field_result
+        else:
+            return OptionWriter(field_result)
 
     def list(self, list_type: ListType, element_result: Writer) -> Writer:
         return ListWriter(element_result)

--- a/python/pyiceberg/avro/writer.py
+++ b/python/pyiceberg/avro/writer.py
@@ -163,7 +163,7 @@ class StructWriter(Writer):
     field_writers: Tuple[Writer, ...] = dataclassfield()
 
     def write(self, encoder: BinaryEncoder, val: StructType) -> None:
-        for writer, value in zip(self.field_writers, val.fields):
+        for writer, value in zip(self.field_writers, val.fields()):
             writer.write(encoder, value)
 
     def __eq__(self, other: Any) -> bool:
@@ -184,6 +184,8 @@ class ListWriter(Writer):
         encoder.write_int(len(val))
         for v in val:
             self.element_writer.write(encoder, v)
+        if len(val) > 0:
+            encoder.write_int(0)
 
 
 @dataclass(frozen=True)
@@ -193,6 +195,8 @@ class MapWriter(Writer):
 
     def write(self, encoder: BinaryEncoder, val: Dict[Any, Any]) -> None:
         encoder.write_int(len(val))
-        for k, v in val:
+        for k, v in val.items():
             self.key_writer.write(encoder, k)
             self.value_writer.write(encoder, v)
+        if len(val) > 0:
+            encoder.write_int(0)

--- a/python/pyiceberg/manifest.py
+++ b/python/pyiceberg/manifest.py
@@ -100,14 +100,14 @@ DATA_FILE_TYPE = StructType(
         field_id=108,
         name="column_sizes",
         field_type=MapType(key_id=117, key_type=IntegerType(), value_id=118, value_type=LongType()),
-        required=True,
+        required=False,
         doc="Map of column id to total size on disk",
     ),
     NestedField(
         field_id=109,
         name="value_counts",
         field_type=MapType(key_id=119, key_type=IntegerType(), value_id=120, value_type=LongType()),
-        required=True,
+        required=False,
         doc="Map of column id to total count, including null and NaN",
     ),
     NestedField(
@@ -171,7 +171,7 @@ class DataFile(Record):
     nan_value_counts: Dict[int, int]
     lower_bounds: Dict[int, bytes]
     upper_bounds: Dict[int, bytes]
-    key_metadata: Optional[bytes]
+    key_metadata: Optional[bytes]   
     split_offsets: Optional[List[int]]
     equality_ids: Optional[List[int]]
     sort_order_id: Optional[int]
@@ -192,7 +192,7 @@ MANIFEST_ENTRY_SCHEMA = Schema(
     NestedField(1, "snapshot_id", LongType(), required=False),
     NestedField(3, "sequence_number", LongType(), required=False),
     NestedField(4, "file_sequence_number", LongType(), required=False),
-    NestedField(2, "data_file", DATA_FILE_TYPE, required=False),
+    NestedField(2, "data_file", DATA_FILE_TYPE, required=True),
 )
 
 

--- a/python/pyiceberg/typedef.py
+++ b/python/pyiceberg/typedef.py
@@ -24,6 +24,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    List,
     Optional,
     Protocol,
     Set,
@@ -155,3 +156,6 @@ class Record(StructProtocol):
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}[{', '.join(f'{key}={repr(value)}' for key, value in self.__dict__.items() if not key.startswith('_'))}]"
+    
+    def fields(self) -> List[str]:
+        return [self.__getattribute__(v) if hasattr(self, v) else None for v in self._position_to_field_name.values()]

--- a/python/pyiceberg/utils/schema_conversion.py
+++ b/python/pyiceberg/utils/schema_conversion.py
@@ -76,7 +76,7 @@ AvroType = Union[str, Any]
 
 
 class AvroSchemaConversion:
-    def avro_to_iceberg(self, avro_schema: dict[str, Any]) -> Schema:
+    def avro_to_iceberg(self, avro_schema: Dict[str, Any]) -> Schema:
         """Converts an Apache Avro into an Apache Iceberg schema equivalent
 
         This expects to have field id's to be encoded in the Avro schema::
@@ -214,7 +214,7 @@ class AvroSchemaConversion:
         else:
             raise TypeError(f"Unknown type: {avro_type}")
 
-    def _convert_field(self, field: dict[str, Any]) -> NestedField:
+    def _convert_field(self, field: Dict[str, Any]) -> NestedField:
         """
         Converts an Avro field into an Iceberg equivalent field
         Args:
@@ -236,7 +236,7 @@ class AvroSchemaConversion:
             doc=field.get("doc"),
         )
 
-    def _convert_record_type(self, record_type: dict[str, Any]) -> StructType:
+    def _convert_record_type(self, record_type: Dict[str, Any]) -> StructType:
         """
         Converts the fields from a record into an Iceberg struct
 
@@ -290,7 +290,7 @@ class AvroSchemaConversion:
 
         return StructType(*[self._convert_field(field) for field in record_type["fields"]])
 
-    def _convert_array_type(self, array_type: dict[str, Any]) -> ListType:
+    def _convert_array_type(self, array_type: Dict[str, Any]) -> ListType:
         if "element-id" not in array_type:
             raise ValueError(f"Cannot convert array-type, missing element-id: {array_type}")
 
@@ -302,7 +302,7 @@ class AvroSchemaConversion:
             element_required=element_required,
         )
 
-    def _convert_map_type(self, map_type: dict[str, Any]) -> MapType:
+    def _convert_map_type(self, map_type: Dict[str, Any]) -> MapType:
         """
         Args:
             map_type: The dict that describes the Avro map type
@@ -338,7 +338,7 @@ class AvroSchemaConversion:
             value_required=value_required,
         )
 
-    def _convert_logical_type(self, avro_logical_type: dict[str, Any]) -> IcebergType:
+    def _convert_logical_type(self, avro_logical_type: Dict[str, Any]) -> IcebergType:
         """
         Convert a schema with a logical type annotation. For the decimal and map
         we need to fetch more keys from the dict, and for the simple ones we can just
@@ -374,7 +374,7 @@ class AvroSchemaConversion:
         else:
             raise ValueError(f"Unknown logical/physical type combination: {avro_logical_type}")
 
-    def _convert_logical_decimal_type(self, avro_type: dict[str, Any]) -> DecimalType:
+    def _convert_logical_decimal_type(self, avro_type: Dict[str, Any]) -> DecimalType:
         """
         Args:
             avro_type: The Avro type
@@ -400,7 +400,7 @@ class AvroSchemaConversion:
         """
         return DecimalType(precision=avro_type["precision"], scale=avro_type["scale"])
 
-    def _convert_logical_map_type(self, avro_type: dict[str, Any]) -> MapType:
+    def _convert_logical_map_type(self, avro_type: Dict[str, Any]) -> MapType:
         """
         In the case where a map hasn't a key as a type you can use a logical map to
         still encode this in Avro
@@ -452,7 +452,7 @@ class AvroSchemaConversion:
             value_required=value.required,
         )
 
-    def _convert_fixed_type(self, avro_type: dict[str, Any]) -> FixedType:
+    def _convert_fixed_type(self, avro_type: Dict[str, Any]) -> FixedType:
         """
         https://avro.apache.org/docs/current/spec.html#Fixed
 


### PR DESCRIPTION
Hi @Fokko , I was trying to implement writing to Iceberg from Python without using pyspark when I found your PR that already implemented some of the steps that are required. With the additions in this PR, I can build the avro files, upload them to S3 and call the API to update the table metadata to point to the metadata and data.

This PR is by no means complete, but I hope to get some feedback on this as I'm keen on having this feature in the pyiceberg library.